### PR TITLE
CERT 8239 Update Tick Offset

### DIFF
--- a/safeguard/uniswap/detector.go
+++ b/safeguard/uniswap/detector.go
@@ -74,7 +74,7 @@ var storageOffsets = storageOffsetsT{
 	feeGrowthGlobal1OffsetFrom0: 1,
 	liquidityOffset:             3,
 
-	tickFeeGrowth0Offset:      2,
+	tickFeeGrowth0Offset:      1,
 	tickFeeGrowth1OffsetFrom0: 1,
 
 	feeGrowthInside0Offset: 1,


### PR DESCRIPTION
https://certora.atlassian.net/browse/CERT-8239
**Title:**  
Fix tick offset error in fee computation to prevent overflow

**Description:**  
This commit resolves an overflow issue in the fee calculation logic caused by an incorrect tick offset. Previously, the offset for `feeGrowthOutside0X128` was set to 2; however, due to the packing of the two int128 values (`liquidityGross` and `liquidityNet`) in the `TickInfo` struct into a single storage slot, the correct offset is 1.

**Details:**  
- **Issue:** The wrong tick offset led to an overflow in fee computations. For example, the fee result was computed as  
  `38565445535701737653391343382242532575460818870235231`  
  instead of the expected value (e.g., `125369` for pool `0x21c67e77...da8a82ca27` and position `0x02e032422e24f69226a497066e04632d79aea2762d6e496cb613ea96f83f67a8`).
- **Root Cause:** According to the `TickInfo` struct:
  - `uint128 liquidityGross`
  - `int128 liquidityNet`  
  These two values are stored in one slot. Therefore, the first fee growth value, `feeGrowthOutside0X128`, is located at offset 1—not offset 2.
- **Fix:** Update the tick offset by changing `tickFeeGrowth0Offset` from 2 to 1. This adjustment ensures that fee results are computed correctly and prevents overflows.
