### PR TITLE
Fix Position hash

### DIFF
--- a/safeguard/uniswap/logscan.go
+++ b/safeguard/uniswap/logscan.go
@@ -188,7 +188,8 @@ func processLogs(
 			toAddress := common.BytesToAddress(l.Topics[2][:])
 			fromAddress := common.BytesToAddress(l.Topics[1][:])
 			amount := new(uint256.Int)
-			amount.SetBytes(l.Data)
+			amount.SetBytes(l.Data[32:64])
+
 			lb.onTransfer(tokenAddress, fromAddress, toAddress, amount)
 		} else {
 			continue


### PR DESCRIPTION
https://certora.atlassian.net/browse/CERT-8251

**Title:** Fix Uniswap Event Parsing for Position and Transfer Events

**Description:**

This PR fixes two issues in the Uniswap log scanning logic:

1. **Position Event Parsing:**  
   The position hash is now computed using the correct topic slice. We use `l.Topics[2][12:32]` (instead of `l.Topics[1][10:32]`) to derive the correct position identifier.

2. **Transfer Event Parsing:**  
   The transfer event’s amount is now extracted correctly from the data payload by slicing `l.Data[32:64]` (instead of using the entire `l.Data`).

These changes ensure that event data is parsed accurately, preventing downstream issues with invariant monitoring.